### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This contains the completed environment setup that we walk through in detail in 
 **NOTE:** For the final demo built in the course, [go here](https://github.com/coryhouse/react-flux-building-applications). 
 And [here's an updated demo](https://github.com/coryhouse/react-flux-building-applications/tree/update) that uses the latest versions as of early 2017.
 
-##This starter kit gives you the following:
+## This starter kit gives you the following:
 - React, React Router, and Flux for ultra-responsive UI development  
 - Browserify bundling  
 - jQuery with Bootstrap for styling  
@@ -17,7 +17,7 @@ And [here's an updated demo](https://github.com/coryhouse/react-flux-building-ap
 -- opens your browser at the dev URL  
 -- reloads the browser upon save  
 
-##To get started:  
+## To get started:  
 1. Install [NodeJS](http://www.nodejs.org)  
 2. Download this repo 
 3. Open the command line of your choice and cd to the root directory of this repo on your machine  
@@ -28,10 +28,10 @@ And [here's an updated demo](https://github.com/coryhouse/react-flux-building-ap
 
 You're now all set to [follow along with the course](http://www.pluralsight.com/author/cory-house)! 
 
-##Having Issues? Try this:
+## Having Issues? Try this:
 1. If you have an .eslintrc file in your user directory, delete it.
 
-##Change Log
+## Change Log
 * Aug 20, 2015 - Updated to use gulp-open 1.0.0 and browserify 11.0.1 since the course has been updated to use these versions.  
 * Jan 23, 2016 - Fixed missing quotes around jQuery globals in .eslintrc.
 * Jan 12, 2017 - Added link to completed demo and updated demo that uses latest versions as of early 2017.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
